### PR TITLE
Patch to ensure large logo always appears on mobile

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import { useContext, useState } from "react";
+import { useContext, useState, useEffect } from "react";
 import { Routes } from "@config/routes";
 import classNames from "classnames";
 import { NavigationContext } from "./navigation-context";
@@ -20,6 +20,19 @@ export function SidebarNavigation() {
   const router = useRouter();
   const { isSidebarCollapsed, toggleSidebar } = useContext(NavigationContext);
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [mobileForm, setMobileForm] = useState(false);
+
+  useEffect(() => {
+    const handleResize = () => {
+      // making assumption that mobile devices will be less than 768 px in width; would need to ascertain through extensive user testing
+      setMobileForm(window.innerWidth <= 768);
+    };
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  });
+
   return (
     <div
       className={classNames(
@@ -37,7 +50,7 @@ export function SidebarNavigation() {
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={
-              isSidebarCollapsed
+              isSidebarCollapsed && !mobileForm
                 ? "/icons/logo-small.svg"
                 : "/icons/logo-large.svg"
             }


### PR DESCRIPTION
Add a 'resize' event listener to the sidebar-navigation.tsx component to capture the innerWidth of the screen. Based on value on innerWidth set boolean to determine if is mobile form factor or not and included that in the ternary assigining the logo file path.